### PR TITLE
Add event and method params

### DIFF
--- a/context-free-parser.js
+++ b/context-free-parser.js
@@ -69,6 +69,21 @@
             case 'type':
               subCurrent[pragma] = content;
               break;
+
+            case 'param':
+              var eventParmsRe = /\{(.+)\}\s+(\w+[.\w+]+)\s+(.*)$/;
+
+              var params = content.match(eventParmsRe);
+              if (params) {
+                var subEventObj = {
+                  type: params[1],
+                  name: params[2],
+                  description: params[3]
+                };
+                makePragma(subCurrent, pragma + 's', subEventObj);
+              }
+
+              break;
   
             // everything else
             default:


### PR DESCRIPTION
Adds support for event and method `@param`. Looks like this: 

![screen shot 2014-07-21 at 8 26 26 pm](https://cloud.githubusercontent.com/assets/238208/3653311/2507f8f2-1150-11e4-8f1c-2d1b5b4013ba.png)

( I still need to upstream core-doc-page style and markup changes from pp.org )
