### PR TITLE
Use /** rather than /* for the @license comment

### DIFF
--- a/context-free-parser.js
+++ b/context-free-parser.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @license
  * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt


### PR DESCRIPTION
@license is jsdoc, and jsdoc is only recognized when it starts with a /**
