### PR TITLE
update package.json to 0.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymer-context-free-parser",
-  "version": "0.4.2",
+  "version": "0.5.6",
   "description": "context-free-parser scrapes source documentation data from input text or url.",
   "main": "context-free-parser.js",
   "repository": {


### PR DESCRIPTION
Currently the latest tag for the repo (0.5.5) does not match the version in package.json.  Can we update to 0.5.6 and get a fresh tag?  The npm registry for polymer-context-free-parser could then use a refresh with this version.  It is using 0.4.2.

Thanks!
