### PR TITLE
fires sub-feature pragma

### DIFF
--- a/context-free-parser.js
+++ b/context-free-parser.js
@@ -80,6 +80,10 @@
               subCurrent[pragma] = content;
               break;
 
+			case 'fires':
+			  makePragma(subCurrent, pragma, content);
+			  break;
+
             case 'param':
               var eventParmsRe = /\{(.+)\}\s+(\w+[.\w+]+)\s+(.*)$/;
 


### PR DESCRIPTION
Methods can now have @fires event to describe what events can be fired from a method call.
